### PR TITLE
Feature/Add Mutation Observer for Job Listings

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -20,8 +20,10 @@ function onMutation(mutationsList, observer) {
   mutationsList.forEach((mutation) => {
     const isChildListMutation = mutation.type === 'childList';
     const hasAddedNodes = mutation.addedNodes.length > 0;
+    const isRelevantTarget =
+      mutation.target.nodeName === 'LI' || mutation.target.nodeName === 'DIV';
 
-    if (!isChildListMutation || !hasAddedNodes) return;
+    if (!isChildListMutation || !hasAddedNodes || !isRelevantTarget) return;
 
     mutation.addedNodes.forEach((node) => {
       const isRelevantNode = node.nodeName === 'LI' || node.nodeName === 'DIV';

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -11,3 +11,27 @@ chrome.runtime.sendMessage(
     );
   }
 );
+
+function listingMutated() {
+  console.log('mutation observed');
+}
+
+function onMutation(mutationsList, observer) {
+  mutationsList.forEach((mutation) => {
+    const isChildListMutation = mutation.type === 'childList';
+    const hasAddedNodes = mutation.addedNodes.length > 0;
+
+    if (!isChildListMutation || !hasAddedNodes) return;
+
+    mutation.addedNodes.forEach((node) => {
+      const isRelevantNode = node.nodeName === 'LI' || node.nodeName === 'DIV';
+
+      if (!isRelevantNode) return;
+
+      listingMutated();
+    });
+  });
+}
+
+const observer = new MutationObserver(onMutation);
+observer.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
This update introduces a MutationObserver to monitor changes in the job listings section of the webpage. The observer is set up to detect the addition of `<LI>` and `<DIV>` elements and ensures that only relevant mutations trigger the observer's callback.

Changes include:
- Implementation of a MutationObserver to track DOM changes within the specified container.
- Logic to check if the added nodes or target elements are `<LI>` or `<DIV>`.
- Simplified condition checks by using descriptive variables.