### PR TITLE
feature/toggle-filter

### DIFF
--- a/scripts/service_worker.js
+++ b/scripts/service_worker.js
@@ -1,5 +1,12 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.get('filtersEnabled', (result) => {
+    if (result.filtersEnabled === undefined) {
+      chrome.storage.local.set({ filtersEnabled: true });
+    }
+  });
+});
+
 chrome.runtime.onConnect.addListener(function (port) {
-  //long term connection
   console.log('Connected to:', port.name);
 
   if (port.name === 'knockknock') {
@@ -9,11 +16,8 @@ chrome.runtime.onConnect.addListener(function (port) {
   }
 });
 
-chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-  //one-time connection
-  if (request.action === 'findList') {
-    chrome.tabs.sendMessage(request.tabId, {
-      action: request.action
-    });
-  }
-});
+chrome.runtime.onMessage.addListener(function (
+  request,
+  sender,
+  sendResponse
+) {});

--- a/ui/popup/popup.html
+++ b/ui/popup/popup.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
-    <button id="jlf_find_list_button">Find listing</button>
+    <button id="jlf_toggle_filters_button">Disable Filters</button>
     <div class="jlf_keyword-section-container">
       <div class="jlf_keyword-container">
         <h3>Job Title Must-Include Keyword</h3>


### PR DESCRIPTION
This PR implements key features and improvements to enhance the user experience with filter functionality in the popup and content script. It introduces the ability to toggle filters on and off, ensures persistence of the filter state across browser sessions, and refactors the codebase to use chrome.storage.local for better data management. Additionally, this PR includes code organization improvements and robust communication between the popup and content scripts.

Key Changes:
- Replaced the "Find listing" button with a new Enable/Disable Filters toggle button in the popup.
- The state of the filter (enabled/disabled) is now saved in chrome.storage.local to ensure persistence across popup sessions and browser restarts.
- When the user toggles the filter, a message is sent from the popup to the active tab’s content script, informing it whether to enable or disable the filter.
- Refactored the content script to receive and handle filter toggle messages to dynamically enable or disable filters.

